### PR TITLE
Add beginning of line symbol to regexes

### DIFF
--- a/els
+++ b/els
@@ -16,13 +16,13 @@ else
   @using_emoji = true
 end
 
-if !ARGV.select{|a| a =~ /-.*R/}.empty?
+if !ARGV.select{|a| a =~ /^-.*R/}.empty?
   puts "els with -R is not recommended"
   exit 1
 end
 
-@long_format = !ARGV.select{|a| a =~ /-.*(l|n|g|o)/}.empty?
-@classify = !ARGV.select{|a| a =~ /-.*F/}.empty?
+@long_format = !ARGV.select{|a| a =~ /^-.*(l|n|g|o)/}.empty?
+@classify = !ARGV.select{|a| a =~ /^-.*F/}.empty?
 
 output = `/bin/ls -F #{ARGV.join(' ')}`
 exit $?.exitstatus if $?.exitstatus != 0
@@ -30,7 +30,7 @@ exit $?.exitstatus if $?.exitstatus != 0
 exit 0 if output == ""
 
 if @long_format
-  newargv = ARGV.collect{|a| a =~ /-.*(l|n|g|o)/ ? a.delete('lngo') : a }.reject{|a| a == '-'}
+  newargv = ARGV.collect{|a| a =~ /^-.*(l|n|g|o)/ ? a.delete('lngo') : a }.reject{|a| a == '-'}
   first_file      = `/bin/ls #{newargv.join(' ')}`.split("\n")[0]
   first_file_line = output.split("\n")[1]
   @file_column = first_file_line.index(first_file)


### PR DESCRIPTION
For issue:   Strange behavior if file/folder/dir name contains dash character #12 

Add ^ (symbol for beginning of line) to regexes when checking ARGV for command line flags.  It had been interpreting file names containing - (dash) as possible flags.

While testing this I noticed another kind of strange behavior when file names contain dashes.  Reverting does not fix it, so it seems to be a separate matter.

Worth noting: I have not tested this change against PR #11, which I first noticed while starting this PR.  I think we're fixing different problems though.